### PR TITLE
Support nodeJS version 12 in objc

### DIFF
--- a/examples/struct.js
+++ b/examples/struct.js
@@ -1,5 +1,5 @@
 const objc = require('../');
-const ffi = require('ffi');
+const ffi = require('ffi-napi');
 const CGFloat = objc.types.double;
 
 const CGPoint = objc.defineStruct('CGPoint', {

--- a/examples/swizzle.js
+++ b/examples/swizzle.js
@@ -1,4 +1,4 @@
-const ref = require('ref');
+const ref = require('ref-napi');
 const objc = require('../src/index');
 
 const {

--- a/examples/touch-id.js
+++ b/examples/touch-id.js
@@ -4,7 +4,7 @@
  * NOTE: This example doesn't work since the reply block will be called on a different thread
  */
 
-const ffi = require('ffi');
+const ffi = require('ffi-napi');
 const objc = require('../src/index.js');
 
 objc.import('LocalAuthentication');

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "url": "https://lukaskollmer.me"
   },
   "main": "./src/index.js",
-  "engines": {
-    "node": ">=8 <12"
-  },
   "scripts": {
     "test_": "ava --verbose --serial",
     "test": "xo && ava --verbose --serial"
@@ -24,9 +21,9 @@
     "runtime"
   ],
   "dependencies": {
-    "ffi": "^2.3.0",
-    "ref": "^1.3.5",
-    "ref-struct": "^1.1.0"
+    "ffi-napi": "^2.4.5",
+    "ref-napi": "1.4.2",
+    "ref-struct-napi": "^1.1.0"
   },
   "devDependencies": {
     "ava": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objc",
-  "version": "0.20.0",
+  "version": "0.30.0",
   "description": "NodeJS ↔ Objective-C bridge",
   "license": "MIT",
   "repository": "lukaskollmer/objc",

--- a/readme.md
+++ b/readme.md
@@ -153,7 +153,7 @@ const substring = string.substringWithRange_(NSRange.new(0, 5));
 <summary><strong>Example 2**</strong> Using structs with the ffi module</summary>
 
 ```js
-const ffi = require('ffi');
+const ffi = require('ffi-napi');
 const CGFloat = objc.types.double;
 
 const CGPoint = objc.defineStruct('CGPoint', {

--- a/src/block.js
+++ b/src/block.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase, key-spacing */
-const ffi = require('ffi');
+const ffi = require('ffi-napi');
 const structs = require('./structs');
 const {pointer, int32, ulonglong} = require('./types');
 const runtime = require('./runtime');

--- a/src/instance.js
+++ b/src/instance.js
@@ -1,4 +1,4 @@
-const ref = require('ref');
+const ref = require('ref-napi');
 const runtime = require('./runtime');
 const Selector = require('./selector');
 const {InstanceProxy} = require('./proxies');

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase, key-spacing, no-multi-spaces, array-bracket-spacing */
 
-const ffi = require('ffi');
-const ref = require('ref');
+const ffi = require('ffi-napi');
+const ref = require('ref-napi');
 
 const dlfcn = new ffi.Library(null, {
   dlopen: ['pointer', ['string', 'int']]

--- a/src/structs.js
+++ b/src/structs.js
@@ -1,4 +1,4 @@
-const struct = require('ref-struct');
+const struct = require('ref-struct-napi');
 
 const CompoundInit = Symbol('structs.CompoundInit');
 const structs = {};

--- a/src/type-encodings.js
+++ b/src/type-encodings.js
@@ -1,6 +1,6 @@
 /* eslint-disable quote-props */
 
-const ref = require('ref');
+const ref = require('ref-napi');
 const structs = require('./structs');
 
 // This file contains the following:

--- a/src/types.js
+++ b/src/types.js
@@ -1,4 +1,4 @@
-const ref = require('ref');
+const ref = require('ref-napi');
 const structs = require('./structs');
 
 const pointer = ref.refType(ref.types.void);

--- a/test.js
+++ b/test.js
@@ -913,7 +913,7 @@ test('[struct] struct as return type', t => {
 });
 
 test('[struct] struct defined in objc module works with ffi module', t => {
-  const ffi = require('ffi');
+  const ffi = require('ffi-napi');
   const libFoundation = new ffi.Library(null, {
     NSStringFromRange: ['pointer', [NSRange]]
   });


### PR DESCRIPTION
In order to support nodeJS 12, we need to use different node modules which can compile with nodeJS 12